### PR TITLE
Add simple year selection menu

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,9 @@
-The aim is to supply a user with a TUI that will aid them in filling in by hand, census pages from the UK and saving the resulting page as an html. 
+The aim is to supply a user with a TUI that assists in filling in census pages from the UK by hand and saves the result as HTML.
 
-Currently it is setup for 1861 only. 
-
-
-all years from 1841-1921 need to be accounted for (as designs)
-
-A user must be able to select the year, then the questions need to be filled in. Then it can save the appropriate details out. 
+Currently it is set up for 1861 only, but the program now starts by asking the
+user which census year they wish to work with.  The list covers 1841 through
+1921.  Once a year is chosen the form appears and can be filled in and saved as
+HTML.
 
 
 


### PR DESCRIPTION
## Summary
- add a startup menu for choosing the census year
- display chosen year in the TUI title
- document year selection in README

## Testing
- `go build ./...` *(fails: Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6877cc2a797c832f8add6cbf95539017